### PR TITLE
Marker update delete only by user

### DIFF
--- a/capstone-project/src/main/angular-webapp/src/app/app.module.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/app.module.ts
@@ -33,7 +33,7 @@ import { environment } from 'src/environments/environment';
   providers: [{
     provide: 'SocialAuthServiceConfig',
     useValue: {
-      autoLogin: false,
+      autoLogin: true,
       providers: [
         {
           id: GoogleLoginProvider.PROVIDER_ID,

--- a/capstone-project/src/main/angular-webapp/src/app/authentication/authentication.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/authentication/authentication.component.ts
@@ -21,7 +21,6 @@ export class AuthenticationComponent implements OnInit {
   // Sign in user
   signInWithGoogle(): void {
     this.authService.signIn(GoogleLoginProvider.PROVIDER_ID);
-    window.location.reload();
   }
 
   // Sign out user and reload page

--- a/capstone-project/src/main/angular-webapp/src/app/authentication/authentication.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/authentication/authentication.component.ts
@@ -21,6 +21,7 @@ export class AuthenticationComponent implements OnInit {
   // Sign in user
   signInWithGoogle(): void {
     this.authService.signIn(GoogleLoginProvider.PROVIDER_ID);
+    window.location.reload();
   }
 
   // Sign out user and reload page

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
@@ -4,7 +4,7 @@
 </head>
 
 <body>
-    <div *ngIf="type==MarkerAction.DISPLAY">
+    <div *ngIf="type==MarkerMode.VIEW || type==MarkerMode.USER_VIEW">
         <h1>{{animal}}</h1>
         <div>
             {{description}}<br> Reported by: {{reporter}}<br>
@@ -14,12 +14,12 @@
             <img [src]="this.domSanitizer.bypassSecurityTrustUrl(imageUrl)" width="200px" height="auto"><br>
             <br>
         </div>
-        <div *ngIf="showEditButtons">
+        <div *ngIf="type==MarkerMode.USER_VIEW">
             <button (click)="delete()">Delete</button>
             <button (click)="update()">Update</button>
         </div>
     </div>
-    <div *ngIf="type==MarkerAction.CREATE">
+    <div *ngIf="type==MarkerMode.CREATE">
         <input #inputAnimal placeholder="Animal"><br>
         <input #inputDescription placeholder="Description"><br>
         <div *ngIf="!user">
@@ -41,7 +41,7 @@
                 (click)="submit(inputAnimal.value, inputDescription.value, inputReporterUser.value)">Submit</button>
         </div>
     </div>
-    <div *ngIf="type==MarkerAction.UPDATE">
+    <div *ngIf="type==MarkerMode.UPDATE">
         <input #inputAnimal value="{{animal}}"><br>
         <input #inputDescription value="{{description}}"><br>
         <input #inputReporter value="{{reporter}}"><br>

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
@@ -9,9 +9,11 @@
         <div>
             {{description}}<br> Reported by: {{reporter}}<br>
         </div>
-        <br>
-        <img *ngIf="imageUrl" [src]="srcUrl" width="200px" height="auto"><br>
-        <br>
+        <div *ngIf="imageUrl">
+            <br>
+            <img [src]="srcUrl" width="200px" height="auto"><br>
+            <br>
+        </div>
         <div *ngIf="showEditButtons">
             <button (click)="delete()">Delete</button>
             <button (click)="update()">Update</button>
@@ -23,16 +25,20 @@
         <div *ngIf="!user">
             <input #inputReporter placeholder="Reporter's Name"><br>
             <form enctype="multipart/form-data">
-                <input #inputImage type="file" name="image" accept="image/png, image/jpg" (change)="postFile($event.target.files)"><br>
+                <input #inputImage type="file" name="image" accept="image/png, image/jpg"
+                    (change)="postFile($event.target.files)"><br>
             </form>
-            <button [disabled]="isUploading" (click)="submit(inputAnimal.value, inputDescription.value, inputReporter.value)">Submit</button>
+            <button [disabled]="isUploading"
+                (click)="submit(inputAnimal.value, inputDescription.value, inputReporter.value)">Submit</button>
         </div>
         <div *ngIf="user">
             <input #inputReporterUser value="{{user.name}}"><br>
             <form enctype="multipart/form-data">
-                <input #inputImage type="file" name="image" accept="image/png, image/jpg" (change)="postFile($event.target.files)"><br>
+                <input #inputImage type="file" name="image" accept="image/png, image/jpg"
+                    (change)="postFile($event.target.files)"><br>
             </form>
-            <button [disabled]="isUploading" (click)="submit(inputAnimal.value, inputDescription.value, inputReporterUser.value)">Submit</button>
+            <button [disabled]="isUploading"
+                (click)="submit(inputAnimal.value, inputDescription.value, inputReporterUser.value)">Submit</button>
         </div>
     </div>
     <div *ngIf="type==MarkerAction.UPDATE">

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
@@ -5,8 +5,10 @@
             {{description}}<br>
             Reported by: {{reporter}}<br>
         </div>
-        <button (click)="delete()">Delete</button>
-        <button (click)="update()">Update</button>
+        <div *ngIf="showEditButtons">
+            <button (click)="delete()">Delete</button>
+            <button (click)="update()">Update</button>
+        </div>
     </div>
     <div *ngIf="type==MarkerAction.CREATE">
         <input #inputAnimal placeholder="Animal"><br>

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
@@ -15,6 +15,7 @@ export class InfoWindowComponent implements OnInit {
   @Input() description: string;
   @Input() reporter: string;
   @Input() type: MarkerAction;
+  @Input() showEditButtons: boolean;
 
   @Output() submitEvent = new EventEmitter();
   @Output() deleteEvent = new EventEmitter();
@@ -37,7 +38,8 @@ export class InfoWindowComponent implements OnInit {
 
   // Indicates that the user pressed on the Delete button
   delete(){
-    this.deleteEvent.emit()
+    let idToken = (this.user ? this.user.idToken : "")
+    this.deleteEvent.emit({userToken: idToken})
   }
 
   // Indicates that the user pressed on the Update button

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
@@ -32,13 +32,13 @@ export class InfoWindowComponent implements OnInit {
     this.animal = animalValue;
     this.description = descriptionValue;
     this.reporter = reporterValue;
-    let idToken = (this.user ? this.user.idToken : "")
+    const idToken = (this.user ? this.user.idToken : "")
     this.submitEvent.emit({animal: animalValue, description: descriptionValue, reporter: reporterValue, userToken: idToken})
   }
 
   // Indicates that the user pressed on the Delete button
   delete(){
-    let idToken = (this.user ? this.user.idToken : "")
+    const idToken = (this.user ? this.user.idToken : "")
     this.deleteEvent.emit({userToken: idToken})
   }
 

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import {DomSanitizer, SafeUrl} from '@angular/platform-browser'
-import { MarkerAction } from '../marker-action';
+import { MarkerMode } from '../marker-mode';
 import { BlobAction } from '../blob-action';
 import { HttpClient } from '@angular/common/http';
 import { } from 'googlemaps';
@@ -19,19 +19,14 @@ export class InfoWindowComponent implements OnInit {
   @Input() description: string;
   @Input() reporter: string;
   @Input() imageUrl : string;
-<<<<<<< HEAD
-  @Input() type: MarkerAction;
-  @Input() showEditButtons: boolean;
-=======
-  @Input() type : MarkerAction;
+  @Input() type: MarkerMode;
   @Input() originalBlobKey : string; // Used when updating the image of an existing marker
->>>>>>> master
 
   @Output() submitEvent = new EventEmitter();
   @Output() deleteEvent = new EventEmitter();
   @Output() updateEvent = new EventEmitter();
 
-  MarkerAction = MarkerAction; // Setting a variable because the HTML template needs it in order to recognize the MarkerAction enum.
+  MarkerMode = MarkerMode; // Setting a variable because the HTML template needs it in order to recognize the MarkerAction enum.
   private blobKeyValue : string;
   isUploading = false; // A flag to avoid submitting a report before the image processing is finished.
 

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
@@ -32,18 +32,12 @@ export class InfoWindowComponent implements OnInit {
     this.animal = animalValue;
     this.description = descriptionValue;
     this.reporter = reporterValue;
-<<<<<<< HEAD
-    const idToken = (this.user ? this.user.idToken : "")
-    this.submitEvent.emit({animal: animalValue, description: descriptionValue, reporter: reporterValue, userToken: idToken})
-=======
     this.submitEvent.emit({animal: animalValue, description: descriptionValue, reporter: reporterValue})
->>>>>>> add-user-id-to-marker-entity
   }
 
   // Indicates that the user pressed on the Delete button
   delete(){
-    const idToken = (this.user ? this.user.idToken : "")
-    this.deleteEvent.emit({userToken: idToken})
+    this.deleteEvent.emit()
   }
 
   // Indicates that the user pressed on the Update button

--- a/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ComponentFactory, ComponentFactoryResolver, Injector, ɵCompiler_compileModuleAndAllComponentsAsync__POST_R3__ } from '@angular/core';
+import { Component, OnInit, ComponentFactory, ComponentFactoryResolver, Injector } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { } from 'googlemaps';
 import { InfoWindowComponent } from '../info-window/info-window.component';

--- a/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ComponentFactory, ComponentFactoryResolver, Injector
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { } from 'googlemaps';
 import { InfoWindowComponent } from '../info-window/info-window.component';
-import { MarkerAction } from '../marker-action';
+import { MarkerMode } from '../marker-mode';
 import { UserService } from '../user.service'
 import { SocialUser } from 'angularx-social-login';
 import { BlobAction } from '../blob-action';
@@ -118,7 +118,7 @@ export class MapComponent implements OnInit {
       .set('userToken', this.user?.idToken);
     this.httpClient.post<any>('/markers', params).subscribe({
       next: data => {
-        if (action == MarkerAction.CREATE) {
+        if (action == MarkerMode.CREATE) {
           marker.id = data.id;
           marker.userId = {value: data.userId};
           this.addMarkerForDisplay(marker);
@@ -133,7 +133,7 @@ export class MapComponent implements OnInit {
 
     const params = new HttpParams()
       .set('id', markerData.id.toString())
-      .set('action', MarkerAction.DELETE.toString())
+      .set('action', MarkerMode.DELETE.toString())
       .set('userToken', this.user?.idToken);
     this.httpClient.post('/markers', params).subscribe({
       error: error => console.error("The marker failed to delete. Error details: ", error)
@@ -163,7 +163,7 @@ export class MapComponent implements OnInit {
   // Build infoWindowComponent and return its HTML element that shows editable textboxes and a submit button.
   buildCreateInfoWindowHtmlElement(lat, lng) {
     const infoWindowComponent = this.factory.create(this.injector);
-    infoWindowComponent.instance.type = MarkerAction.CREATE;
+    infoWindowComponent.instance.type = MarkerMode.CREATE;
     infoWindowComponent.changeDetectorRef.detectChanges();
 
     infoWindowComponent.instance.submitEvent.subscribe(event => {
@@ -175,7 +175,7 @@ export class MapComponent implements OnInit {
         lng: lng,
         blobKey: event.blobKey
       };
-      this.postMarker(newMarker, MarkerAction.CREATE);
+      this.postMarker(newMarker, MarkerMode.CREATE);
 
       // Get the image URL from the blob key so we can add the new marker for display
       if (newMarker.blobKey) {
@@ -229,9 +229,9 @@ export class MapComponent implements OnInit {
     infoWindowComponent.instance.description = marker.description;
     infoWindowComponent.instance.reporter = marker.reporter;
     infoWindowComponent.instance.imageUrl = imageUrl;
-    infoWindowComponent.instance.type = MarkerAction.DISPLAY;
+    infoWindowComponent.instance.type = MarkerMode.VIEW;
     if (this.user && marker.userId.value == this.user.id) {
-      infoWindowComponent.instance.showEditButtons = true;
+      infoWindowComponent.instance.type = MarkerMode.USER_VIEW;
     }
     infoWindowComponent.changeDetectorRef.detectChanges();
     return infoWindowComponent;
@@ -240,7 +240,7 @@ export class MapComponent implements OnInit {
   // Edits the InfoWindowComponent instance letting the user update the fields of an existing marker.
   buildUpdateInfoWindowHtmlElment(markerData, infoWindowComponent) {
 
-    infoWindowComponent.instance.type = MarkerAction.UPDATE;
+    infoWindowComponent.instance.type = MarkerMode.UPDATE;
     infoWindowComponent.instance.originalBlobKey = markerData.blobKey;
     infoWindowComponent.changeDetectorRef.detectChanges();
 
@@ -254,10 +254,10 @@ export class MapComponent implements OnInit {
         lng: markerData.lng,
         blobKey: event.blobKey
       };
-      this.postMarker(newMarker, MarkerAction.UPDATE);
+      this.postMarker(newMarker, MarkerMode.UPDATE);
 
       // Once the user clicks "Update", we want to return the regular display with the updated image
-      infoWindowComponent.instance.type = MarkerAction.DISPLAY;
+      infoWindowComponent.instance.type = MarkerMode.USER_VIEW;
       if (newMarker.blobKey) {
         this.httpClient.get('/blob-service?' + 'blobAction=' + BlobAction.KEY_TO_BLOB + '&blob-key=' + newMarker.blobKey, { responseType: 'blob' })
           .toPromise()

--- a/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
@@ -41,10 +41,11 @@ export class MapComponent implements OnInit {
       this.addMarkerForEdit(event.latLng.lat(), event.latLng.lng());
     });
 
-    // Fetches markers from the backend and adds them to the map.
+    // When a user is updated, remove all marker and display them with correct buttons
     this.userService.getUserObservable().subscribe(user => {
       this.markers.forEach(marker => marker.setMap(null));
       this.markers = [];
+      // Fetches markers from the backend and adds them to the map.
       this.httpClient.get('/markers')
       .toPromise()
       .then((response) => {

--- a/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/map/map.component.ts
@@ -268,5 +268,4 @@ export class MapComponent implements OnInit {
   get user(): SocialUser {
     return this.userService.getUser();
   }
-
 }

--- a/capstone-project/src/main/angular-webapp/src/app/marker-action.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/marker-action.ts
@@ -1,4 +1,0 @@
-// enum of the marker actions available
-export enum MarkerAction {
-    CREATE, UPDATE, DELETE, DISPLAY
-}

--- a/capstone-project/src/main/angular-webapp/src/app/marker-mode.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/marker-mode.ts
@@ -1,0 +1,4 @@
+// enum of the marker actions available
+export enum MarkerMode {
+    CREATE, UPDATE, DELETE, VIEW, USER_VIEW
+}

--- a/capstone-project/src/main/angular-webapp/src/app/user.service.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/user.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { SocialUser } from 'angularx-social-login';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -8,12 +9,15 @@ export class UserService {
 
   // Holds the current user, updated in authentication component
   private currentUser;
+  private userSource = new BehaviorSubject<SocialUser>(null);
+  userObservable = this.userSource.asObservable();
 
   constructor() {  }
 
   // Update current user
   setUser(user: SocialUser){
     this.currentUser = user;
+    this.userSource.next(user);
   }
 
   // Return the current user

--- a/capstone-project/src/main/angular-webapp/src/app/user.service.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { SocialUser } from 'angularx-social-login';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +10,7 @@ export class UserService {
   // Holds the current user, updated in authentication component
   private currentUser;
   private userSource = new BehaviorSubject<SocialUser>(null);
-  userObservable = this.userSource.asObservable();
+  private userObservable = this.userSource.asObservable();
 
   constructor() {  }
 
@@ -23,6 +23,11 @@ export class UserService {
   // Return the current user
   getUser(): SocialUser {
     return this.currentUser;
+  }
+
+  // Returns the userObservable
+  getUserObservable(): Observable<SocialUser> {
+    return this.userObservable;
   }
 
 }

--- a/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
+++ b/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
@@ -97,22 +97,24 @@ public class MarkerServlet extends HttpServlet {
                 Marker updatedMarker = gson.fromJson(request.getParameter("marker"), Marker.class);
                 try {
                     updateMarker(updatedMarker, userId);
-                } catch (EntityNotFoundException e) {
-                    context.log("Update failed, Entity not found. Error details: ", e);
-                }
-                catch (GeneralSecurityException securityException) {
-                    response.getWriter().println("Update failed, " + securityException.toString());
+                } catch (EntityNotFoundException entityNotFoundException) {
+                    context.log("Update failed, Entity not found. Error details: ",
+                        entityNotFoundException);
+                } catch (GeneralSecurityException securityException) {
+                    context.log("Update failed, security problem. Error details:",
+                    securityException);
                 }
                 break;
             case DELETE:
                 markerId = Long.parseLong(request.getParameter("id"));
                 try {
                     deleteMarker(markerId, userId);
-                } catch (EntityNotFoundException e) {
-                    response.getWriter().println("Delete failed, Entity not found. Error details: " + e.toString());
-                }
-                catch (GeneralSecurityException securityException) {
-                    response.getWriter().println("Delete failed, " + securityException.toString());
+                } catch (EntityNotFoundException entityNotFoundException) {
+                    context.log("Delete failed, Entity not found. Error details: ",
+                    entityNotFoundException);
+                } catch (GeneralSecurityException securityException) {
+                    context.log("Delete failed, security problem. Error details:",
+                    securityException);
                 }
         }
     }
@@ -164,7 +166,7 @@ public class MarkerServlet extends HttpServlet {
         return markerEntity.getKey().getId();
     }
 
-    /** Updates an existing marker's data */
+    /** Updates an existing marker's data if the request was from the uploader */
     private static void updateMarker(Marker marker, Optional<String> userId) throws EntityNotFoundException, GeneralSecurityException {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
@@ -182,7 +184,7 @@ public class MarkerServlet extends HttpServlet {
         }       
     }
 
-    /** Deletes a marker */
+    /** Deletes a marker if the request was from the uploader*/
     private static void deleteMarker(long markersId, Optional<String> userId) throws EntityNotFoundException, GeneralSecurityException {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Key markerEntityKey = KeyFactory.createKey("Marker", markersId);

--- a/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
+++ b/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
@@ -83,15 +83,15 @@ public class MarkerServlet extends HttpServlet {
         switch (action) {
             case CREATE:
                 Marker newMarker = gson.fromJson(request.getParameter("marker"), Marker.class);
-                HashMap<String, String> returnParameters = new HashMap<>();
+                HashMap<String, String> responseParameters = new HashMap<>();
                 newMarker.setUserId(userId);
                 markerId = storeMarker(newMarker);
                 // The ID of the entity need to be updated in the FE as well
-                returnParameters.put("id", Long.toString(markerId));
+                responseParameters.put("id", Long.toString(markerId));
                 if (userId.isPresent()){
-                    returnParameters.put("userId", userId.get());
+                    responseParameters.put("userId", userId.get());
                 }
-                response.getWriter().println(gson.toJson(returnParameters));
+                response.getWriter().println(gson.toJson(responseParameters));
                 break;
             case UPDATE:
                 Marker updatedMarker = gson.fromJson(request.getParameter("marker"), Marker.class);

--- a/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
+++ b/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
@@ -97,24 +97,16 @@ public class MarkerServlet extends HttpServlet {
                 Marker updatedMarker = gson.fromJson(request.getParameter("marker"), Marker.class);
                 try {
                     updateMarker(updatedMarker, userId);
-                } catch (EntityNotFoundException entityNotFoundException) {
-                    context.log("Update failed, Entity not found. Error details: ",
-                        entityNotFoundException);
-                } catch (GeneralSecurityException securityException) {
-                    context.log("Update failed, security problem. Error details:",
-                    securityException);
+                } catch (EntityNotFoundException | GeneralSecurityException e) {
+                    context.log("Update failed. Error details: ", e);
                 }
                 break;
             case DELETE:
                 markerId = Long.parseLong(request.getParameter("id"));
                 try {
                     deleteMarker(markerId, userId);
-                } catch (EntityNotFoundException entityNotFoundException) {
-                    context.log("Delete failed, Entity not found. Error details: ",
-                    entityNotFoundException);
-                } catch (GeneralSecurityException securityException) {
-                    context.log("Delete failed, security problem. Error details:",
-                    securityException);
+                } catch (EntityNotFoundException | GeneralSecurityException e) {
+                    context.log("Update failed. Error details: ", e);
                 }
         }
     }

--- a/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
+++ b/capstone-project/src/main/java/com/google/sps/servlets/MarkerServlet.java
@@ -87,7 +87,7 @@ public class MarkerServlet extends HttpServlet {
                 // The ID of the entity need to be updated in the FE as well
                 returnParameters.put("id", Long.toString(markerId));
                 if (userId.isPresent()){
-                    returnParameters.put("userId", (userId.get()));
+                    returnParameters.put("userId", userId.get());
                 }
                 response.getWriter().println(gson.toJson(returnParameters));
                 break;


### PR DESCRIPTION
Only authenticated users can edit and delete their own markers
Hiding the delete and update buttons on all markers that do not relate to current user
Checking the userId before updating or delete marker in back-end
Currently in order to display the info-windows correctly we delete them and display them again when a user signs in. We will fix that in future PRs so the info window will generate only after a user clicks on it (and there will be no use to update all of them every time)
![image](https://user-images.githubusercontent.com/54071800/96469029-70cd4700-1235-11eb-8f1d-6ddcaa4c7bd4.png)

Changes not related to feature - 
* In app module we changed the autoLogin flag so user will stay logged in after page reload
* In info-window template we wrapped the img in div so <br> will not appear unless there is an image (otherwise info-window looks bad)