### PR TITLE
Map component testing - Part 2

### DIFF
--- a/capstone-project/src/main/angular-webapp/src/app/map/map.component.spec.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/map/map.component.spec.ts
@@ -172,4 +172,22 @@ describe('MapComponent', () => {
       .toHaveBeenCalledWith(jasmine.any(Object), MarkerMode.UPDATE);
   });
 
+  it('should get markers from backend and display them', async () => {
+    spyOn(component, 'addMarkerForDisplay');
+    
+    // Markers fetched from backend in ngOnInit
+    await component.ngOnInit();
+
+    expect(component.addMarkerForDisplay)
+      .toHaveBeenCalledWith(MockHttpInterceptor.getResponseMarker());
+  });
+
+  it('should send http post when postMarker method is called', async () => {
+    spyOn(component["httpClient"], "post").and.callThrough();
+
+    await component.postMarker(MockHttpInterceptor.getResponseMarker(), MarkerMode.CREATE);
+
+    expect(component["httpClient"].post).toHaveBeenCalled();
+  });
+
 });

--- a/capstone-project/src/main/angular-webapp/src/app/map/map.component.spec.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/map/map.component.spec.ts
@@ -65,19 +65,6 @@ describe('MapComponent', () => {
     });
   });
 
-  // afterEach(() => {
-  //   component = null;
-  //   fixture = null;
-  //   fakeMarker = null;
-  //   fakeMarkerForDisplay = null;
-  //   infoWindowComponent = null;
-  //   clickArgs = null;
-  // });
-
-  afterAll(() => {
-    TestBed.resetTestEnvironment();
-  });
-
   it('should create', () => {
     expect(component).toBeTruthy();
   });

--- a/capstone-project/src/main/angular-webapp/src/app/mock-http-interceptor.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/mock-http-interceptor.ts
@@ -1,7 +1,9 @@
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from "@angular/common/http";
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpParams, HttpRequest, HttpResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
+import { Mock } from 'protractor/built/driverProviders';
 import { Observable, of } from "rxjs";
 import { BlobAction } from "./blob-action";
+import { MarkerMode } from './marker-mode';
 
 // Mock the HttpClient's interceptor so that HTTP requests are handled locally and not in the real back end.
 @Injectable()
@@ -13,6 +15,28 @@ export class MockHttpInterceptor implements HttpInterceptor {
   private static responseKey = {
     blobKey: "blobKey"
   }
+
+  private static responseMarker = {
+    animal: "",
+    description: "",
+    reporter: "",
+    lat: 40,
+    lng: 90,
+    blobKey: "",
+    userId: { value: "0" }
+  }
+
+  private static markerJson = JSON.stringify(MockHttpInterceptor.responseMarker);
+
+  private static responseId = {
+    id: 0
+  };
+
+  private static postCreateParams = new HttpParams()
+  .set('marker', MockHttpInterceptor.markerJson)
+  .set('action', MarkerMode.CREATE.toString())
+  .set('userToken', undefined);
+  
 
   constructor() { }
 
@@ -26,6 +50,18 @@ export class MockHttpInterceptor implements HttpInterceptor {
     return MockHttpInterceptor.responseKey.blobKey;
   }
 
+  // Getter for responseMarkers
+  static getResponseMarker() {
+    return MockHttpInterceptor.responseMarker;
+  }
+
+  // Compare two HttpParams of postMarker
+  static compareParams(params1: HttpParams, params2: HttpParams) {
+    return (params1.get('marker') === params2.get('marker') &&
+    params1.get('action') === params2.get('action') &&
+    params1.get('userToken') === params2.get('userToken'))
+  }
+
   // Handles get / post requests
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
@@ -34,6 +70,13 @@ export class MockHttpInterceptor implements HttpInterceptor {
     }
     else if (req.method === "POST" && req.url === MockHttpInterceptor.responseUrl.imageUrl) {
       return of(new HttpResponse({ status: 200, body: MockHttpInterceptor.responseKey }));
+    }
+    else if (req.method === "GET" && req.url === '/markers') {
+      return of(new HttpResponse({ status: 200, body: [MockHttpInterceptor.responseMarker] }));
+    }
+    else if (req.method === "POST" && req.url === '/markers' 
+    && MockHttpInterceptor.compareParams(req.body, MockHttpInterceptor.postCreateParams)) {
+      return of(new HttpResponse({ status: 200, body: MockHttpInterceptor.responseId }));
     }
 
     next.handle(req);


### PR DESCRIPTION
Moved variables used in more then one test to beforeEach
Added to MockHttpInterceptor the intercept cases and the relevant data for the map component http post and get.
In MockHttpInterceptor comparing req.body and MockHttpInterceptor.postCreateParams with "==" didn't work so I added the compare method that compares all the relevant fields.
Add tests:
* Marker generates when user clicks on the map
* Marker updates after info-window update event emits
* Marker deletes after info-window delete event emits
* Marker post with create mode after info-window submit event emits
* Marker post with update mode  after info-window submit event from update emits
* Http get is called on ngOnInit
* Http post is called in postMarker
