### PR TITLE
Avoid Empty Markers

### DIFF
--- a/capstone-project/src/main/angular-webapp/src/app/app.module.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { GoogleMapsModule } from '@angular/google-maps';
-import { FormsModule } from '@angular/forms'
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SocialLoginModule, SocialAuthServiceConfig } from 'angularx-social-login';
@@ -27,7 +26,6 @@ import { ToastService } from './toast/toast.service'
     AppRoutingModule,
     HttpClientModule,
     GoogleMapsModule,
-    FormsModule,
     BrowserAnimationsModule,
     SocialLoginModule,
     MaterialModule

--- a/capstone-project/src/main/angular-webapp/src/app/app.module.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { GoogleMapsModule } from '@angular/google-maps';
+import { FormsModule } from '@angular/forms'
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { SocialLoginModule, SocialAuthServiceConfig } from 'angularx-social-login';
@@ -26,6 +27,7 @@ import { ToastService } from './toast/toast.service'
     AppRoutingModule,
     HttpClientModule,
     GoogleMapsModule,
+    FormsModule,
     BrowserAnimationsModule,
     SocialLoginModule,
     MaterialModule

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
@@ -26,7 +26,7 @@
     <div *ngIf="type==MarkerMode.CREATE">
         <mat-form-field floatLabel="always" appearance="outline">
             <mat-label>Animal</mat-label>
-            <input matInput #inputAnimal [(ngModel)]="animalName"><br>
+            <input matInput #inputAnimal><br>
         </mat-form-field>
         <br>
         <mat-form-field floatLabel="always" appearance="outline">
@@ -46,7 +46,7 @@
                 <p id="file-name">
             </form>
             <br>
-            <button id="submitButton" mat-stroked-button style="float: right;" [disabled]="isUploading || !animalName" (click)="submit(inputAnimal.value, inputDescription.value, inputReporter.value)">
+            <button id="submitButton" mat-stroked-button style="float: right;" [disabled]="isUploading" (click)="submit(inputAnimal.value, inputDescription.value, inputReporter.value)">
                 <mat-icon>done</mat-icon>
             </button>
             <br>
@@ -115,4 +115,5 @@
         </button>
         <br>
     </div>
+    <div id="ej2Toast" #toast></div>
 </body>

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.html
@@ -26,7 +26,7 @@
     <div *ngIf="type==MarkerMode.CREATE">
         <mat-form-field floatLabel="always" appearance="outline">
             <mat-label>Animal</mat-label>
-            <input matInput #inputAnimal><br>
+            <input matInput #inputAnimal [(ngModel)]="animalName"><br>
         </mat-form-field>
         <br>
         <mat-form-field floatLabel="always" appearance="outline">
@@ -46,7 +46,7 @@
                 <p id="file-name">
             </form>
             <br>
-            <button id="submitButton" mat-stroked-button style="float: right;" [disabled]="isUploading" (click)="submit(inputAnimal.value, inputDescription.value, inputReporter.value)">
+            <button id="submitButton" mat-stroked-button style="float: right;" [disabled]="isUploading || !animalName" (click)="submit(inputAnimal.value, inputDescription.value, inputReporter.value)">
                 <mat-icon>done</mat-icon>
             </button>
             <br>

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.spec.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.spec.ts
@@ -6,6 +6,12 @@ import 'jasmine';
 import { InfoWindowComponent } from './info-window.component';
 import { MarkerMode } from '../marker-mode';
 import { MockHttpInterceptor } from '../mock-http-interceptor'
+import { ToastService } from '../toast/toast.service';
+
+// Mock toast service for empty marker error
+class MockToastService {
+  showToast() {}
+}
 
 describe('InfoWindowComponent', () => {
   let component: InfoWindowComponent;
@@ -19,6 +25,9 @@ describe('InfoWindowComponent', () => {
         provide: HTTP_INTERCEPTORS,
         useClass: MockHttpInterceptor,
         multi: true
+      }, {
+        provide: ToastService,
+        useClass: MockToastService
       }]
     });
     fixture = TestBed.createComponent(InfoWindowComponent);
@@ -36,16 +45,32 @@ describe('InfoWindowComponent', () => {
     expect(component.getBlobKeyValue()).toBe("originalKey");
   });
 
-  it('Should emit on submit', () => {
+  it('Should call "submit" function on submit click', () => {
 
     component.type = MarkerMode.CREATE;
     fixture.detectChanges();
-    spyOn(component.submitEvent, 'emit');
+    spyOn(component, 'submit');
     
     // Trigger the submit event
     fixture.debugElement.nativeElement.querySelector('#submitButton').click();
 
+    expect(component.submit).toHaveBeenCalled();
+  });
+
+  it('Should emit on submission', () => {
+    spyOn(component.submitEvent, 'emit');
+
+    component.submit("animal", "descriprion", "reporter");
+
     expect(component.submitEvent.emit).toHaveBeenCalled();
+  });
+
+  it('Should fail to submit a marker with an empty "animal" field', () => {
+    spyOn(component["toastService"], "showToast");
+
+    component.submit("", "description", "reporter");
+
+    expect(component["toastService"].showToast).toHaveBeenCalled();
   });
 
   it('Should emit on delete', () => {

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.spec.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.spec.ts
@@ -46,7 +46,6 @@ describe('InfoWindowComponent', () => {
   });
 
   it('Should call "submit" function on submit click', () => {
-
     component.type = MarkerMode.CREATE;
     fixture.detectChanges();
     spyOn(component, 'submit');

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
@@ -45,7 +45,7 @@ export class InfoWindowComponent implements OnInit {
 
   // Update the fields according to user input and emit the submitEvent to receive the data in mapComponenet
   submit(animalValue, descriptionValue, reporterValue) {
-    
+
     // Avoid submitting an empty marker
     if(!animalValue) {
       this.toastService.showToast(document.getElementById("ej2Toast"), {

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
@@ -30,6 +30,7 @@ export class InfoWindowComponent implements OnInit {
   MarkerMode = MarkerMode; // Setting a variable because the HTML template needs it in order to recognize the MarkerAction enum.
   private blobKeyValue : string;
   isUploading = false; // A flag to avoid submitting a report before the image processing is finished.
+  animalName : string = "";
 
   constructor(private httpClient: HttpClient, public domSanitizer: DomSanitizer, private userService: UserService) { }
 

--- a/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
+++ b/capstone-project/src/main/angular-webapp/src/app/info-window/info-window.component.ts
@@ -6,6 +6,7 @@ import { HttpClient } from '@angular/common/http';
 import { } from 'googlemaps';
 import { SocialUser } from "angularx-social-login";
 import { UserService } from "../user.service";
+import { ToastService } from '../toast/toast.service';
 
 @Component({
   selector: 'app-info-window',
@@ -30,9 +31,8 @@ export class InfoWindowComponent implements OnInit {
   MarkerMode = MarkerMode; // Setting a variable because the HTML template needs it in order to recognize the MarkerAction enum.
   private blobKeyValue : string;
   isUploading = false; // A flag to avoid submitting a report before the image processing is finished.
-  animalName : string = "";
 
-  constructor(private httpClient: HttpClient, public domSanitizer: DomSanitizer, private userService: UserService) { }
+  constructor(private httpClient: HttpClient, public domSanitizer: DomSanitizer, private userService: UserService, private toastService: ToastService) { }
 
   ngOnInit(): void { 
     this.blobKeyValue = this.originalBlobKey;
@@ -45,6 +45,16 @@ export class InfoWindowComponent implements OnInit {
 
   // Update the fields according to user input and emit the submitEvent to receive the data in mapComponenet
   submit(animalValue, descriptionValue, reporterValue) {
+    
+    // Avoid submitting an empty marker
+    if(!animalValue) {
+      this.toastService.showToast(document.getElementById("ej2Toast"), {
+        title: "Couldn't Submit Report",
+        content: "Please fill in the 'Animal' field."
+      });
+      return;
+    }
+
     this.animal = animalValue;
     this.description = descriptionValue;
     this.reporter = reporterValue;


### PR DESCRIPTION
- Display a toast alert when the user tries to submit a report with an empty 'animal name' field.
- Test the new functionality 